### PR TITLE
Fix phase offset for rotation_error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+lab1/src/\.vscode/c_cpp_properties\.json
+
+lab1/src/\.vscode/

--- a/lab1/launch/line_follower.launch
+++ b/lab1/launch/line_follower.launch
@@ -2,12 +2,12 @@
    <node name = "line_follower" type="line_follower.py" pkg="lab1" output="screen">
    		<param name="plan_topic" type="string" value="/planner_node/car_plan"/>   		
    		<param name="pose_topic" type="string" value="/sim_car_pose"/>
-      <param name="plan_lookahead" type="double" value="2"/>
+      <param name="plan_lookahead" type="double" value="1"/>
       <param name="translation_weight" type="double" value="1.0"/>
-      <param name="rotation_weight" type="double" value="1.0"/>
-      <param name="kp" type="double" value="1"/>
+      <param name="rotation_weight" type="double" value=".5"/>
+      <param name="kp" type="double" value="30"/>
+      <param name="kd" type="double" value="3.0"/>
       <param name="ki" type="double" value="0.0"/>
-      <param name="kd" type="double" value=".2"/>
       <param name="error_buff_length" type="double" value="10"/>
       <param name="speed" type="double" value="1.0"/>   
    </node>

--- a/lab1/src/line_follower.py
+++ b/lab1/src/line_follower.py
@@ -147,7 +147,7 @@ class LineFollower:
     goal_idx_y = self.plan[goal_idx,1]
     goal_idx_th = self.plan[goal_idx,2]
 
-    # Unit vector in the direction of the goal pose
+    # Unit vector in the same orientation as the goal pose
     goal_unit_vector = [np.cos(goal_idx_th), np.sin(goal_idx_th)]
 
     # Vector between the current pose and the goal pose 
@@ -155,7 +155,7 @@ class LineFollower:
     
     # Use the cross product to calculate the distance error to capture positive or negative wrt to goal_unit_vector
     translation_error = np.cross(distance_vector, goal_unit_vector)
-    rotation_error= goal_idx_th - cur_pose_th 
+    rotation_error= ((goal_idx_th - cur_pose_th + np.pi) % (2*np.pi)) - np.pi  # Needed in order to constrain this difference to the interval [-pi, pi] as opposed to [-2*pi, 2*pi] 
 
     # rospy.loginfo("translation error ")
     # rospy.loginfo(translation_error)

--- a/lab1/src/line_follower.py
+++ b/lab1/src/line_follower.py
@@ -79,32 +79,27 @@ class LineFollower:
         #   the configuration is in front or behind the robot
         # If the configuration is in front of the robot, break out of the loop
 
-    # Check if the plan is empty. If so, return (False, 0.0)
-
-    if len(self.plan)==0: 
-
-      return (False, 0.0)
-
     #Current position of car     
     cur_pose_x = cur_pose[0]
     cur_pose_y = cur_pose[1]
     cur_pose_th = cur_pose[2]
 
+    
+    #Initialize i, incrementer
     i = 0 
-
     while len(self.plan) > 0:
-      # YOUR CODE HERE. 
       # This code starts at the beginning of self.plan and marches forward until 
       # it encounters a pose that is in front of the car 
       # To do this, simply we will make use of the dot product instead of coordinate transformations.
       # First calculate vector between carPose and planPose, vectorC2P
       # If dot product between carPose unit vector and vectorC2P is positive, then the point is in front 
       # If dot product between carPose unit vector and vectorC2P is negative, then the point is behind 
-
-      target_x = self.plan[i,0]
-      target_y = self.plan[i,1]
-      target_th = self.plan[i,2]
-      i = i+1 
+      if len(self.plan)==1:
+        [target_x, target_y, target_th]= self.plan[0]
+      else:
+        target_x = self.plan[i,0]
+        target_y = self.plan[i,1]
+        target_th = self.plan[i,2]
 
       # Vector between ith pose and the current car pse
       vectorC2P = [target_x - cur_pose_x, target_y - cur_pose_y]
@@ -117,17 +112,27 @@ class LineFollower:
 
       # If dot product is positive value, then the target node is in front 
       # Break out of the while loop if dot product if target node is in front
-      if dotProduct > 0: 
+
+      rospy.loginfo(dotProduct)
+      if dotProduct > -0.2: 
         break 
     
       #Remove the first pose in self.plan 
       self.plan = self.plan[1:]
 
-      # # Prints the length of the plan. 
-        # rospy.loginfo("self.plan length")
-        # rospy.loginfo(len(self.plan))
+      
+      # Prints the length of the plan. 
+      # rospy.loginfo("self.plan length")
+      # rospy.loginfo(len(self.plan))
 
+      # Increment i 
+      i = i+1 
     
+    # Check if the plan is empty. If so, return (False, 0.0)
+    if len(self.plan)==0: 
+
+      return (False, 0.0)
+
     # At this point, we have removed configurations from the plan that are behind
     # the robot. Therefore, element 0 is the first configuration in the plan that is in 
     # front of the robot. To allow the robot to have some amount of 'look ahead',
@@ -136,7 +141,7 @@ class LineFollower:
     goal_idx = min(0+self.plan_lookahead, len(self.plan)-1)
    
     # Compute the translation error between the robot and the configuration at goal_idx in the plan
-    # YOUR CODE HERE
+    rospy.loginfo(len(self.plan))
 
     goal_idx_x = self.plan[goal_idx,0]
     goal_idx_y = self.plan[goal_idx,1]


### PR DESCRIPTION
This fixes the intermittent bug that was causing the simcar to turn the wrong direction under some circumstances. rotation_error = (Theta_guide - Theta_car) was previously bounded on the range [-2*pi, 2*pi] which could result in rapid sign shifts in the error term if thetas wrapped over the -pi <-> +pi boundary. This commit re-maps it to the range [-pi, pi].