### PR TITLE
Change pose_array datatype to deque for better performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 lab1/src/\.vscode/c_cpp_properties\.json
 
 lab1/src/\.vscode/
+
+lab1/\.vscode/
+
+lab1/src/utils\.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,2 @@
-
-lab1/src/\.vscode/c_cpp_properties\.json
-
-lab1/src/\.vscode/
-
-lab1/\.vscode/
-
-lab1/src/utils\.pyc
+# Ignore .pyc files since these are binaries compiled at runtime
+*.pyc

--- a/lab1/launch/line_follower.launch
+++ b/lab1/launch/line_follower.launch
@@ -1,7 +1,7 @@
 <launch>
    <node name = "line_follower" type="line_follower.py" pkg="lab1" output="screen">
    		<param name="plan_topic" type="string" value="/planner_node/car_plan"/>   		
-   		<param name="pose_topic" type="string" value="/sim_car_pose"/>
+   		<param name="pose_topic" type="string" value="/sim_car_pose/pose"/>
       <param name="plan_lookahead" type="double" value="1"/>
       <param name="translation_weight" type="double" value="1.0"/>
       <param name="rotation_weight" type="double" value=".5"/>


### PR DESCRIPTION
This seems to fix the occasional errors that can happen where the callback function tried to index out of the array bounds. Saves re-writing the array each time we take off an element, and should prevent errors even if multiple instances of compute_error get called by pose_cb's simultaneously. Note: there's a small chance that two poses could get re-written to the array out of order if this happens. Think that's still better than erroring, but the ideal solution would be to limit pose_cb to one simultaneous instance.